### PR TITLE
[fix] BackGround Image 렌더 버그 수정

### DIFF
--- a/D2D-AliceEngine/D2D-AliceEngine/Scripts/BackGroundVideo.cpp
+++ b/D2D-AliceEngine/D2D-AliceEngine/Scripts/BackGroundVideo.cpp
@@ -25,14 +25,17 @@ void BackGroundVideo::Update(const float& deltaSeconds)
 	FVector2 playerPos = m_player->transform()->GetPosition();
 	FVector2 myPos = m_owner->transform()->GetPosition();
 
-	m_owner->transform()->SetPosition(playerPos.x, 550);
+	
+	float size = m_owner->GetComponent<BackGroundComponent>()->GetBitmapSizeX();
+
+	m_owner->transform()->SetPosition(playerPos.x - size / 2, 550);
 	//m_owner->transform()->SetPosition(playerPos.x, Define::SCREEN_HEIGHT);
 }
 
 void BackGroundVideo::OnStart()
 {
 	m_owner = GetOwner();
-	m_owner->transform()->SetScale(0.3f, 0.3f);
+	m_owner->transform()->SetScale(1, 1);
 
 	//m_owner->AddComponent<BackGroundComponent>()->LoadData(L"BackGround\\Alice.webm", 10, L"jpg", 95, true);
 	m_owner->AddComponent<BackGroundComponent>()->LoadFromFolder(L"BackGround\\Ena", 5, L"png");

--- a/D2D-AliceEngine/Engine/Component/BackGroundComponent.cpp
+++ b/D2D-AliceEngine/Engine/Component/BackGroundComponent.cpp
@@ -109,7 +109,7 @@ void BackGroundComponent::LoadFromFolder(const std::wstring& folderPath, int fps
 
 	m_fFPSTime = 1.0f / fps;
 	m_maxClipSize = files.size();
-	m_curClip = 0;
+	m_curClip = files.size()-1;
 	m_bitmaps.clear();
 	m_bitmaps.resize(m_maxClipSize);
 
@@ -231,18 +231,18 @@ void BackGroundComponent::Render()
 
 float BackGroundComponent::GetBitmapSizeX()
 {
-	if (m_bitmaps.empty() == false)
+	if (m_bitmaps.empty() == false && GetOwner())
 	{
-		return static_cast<float>(bmpSize.width);
+		return static_cast<float>(bmpSize.width) * owner->transform()->GetScale().x;
 	}
 	return 0;
 }
 
 float BackGroundComponent::GetBitmapSizeY()
 {
-	if (m_bitmaps.empty() == false)
+	if (m_bitmaps.empty() == false && GetOwner())
 	{
-		return static_cast<float>(bmpSize.height);
+		return static_cast<float>(bmpSize.height) * owner->transform()->GetScale().x;
 	}
 	return 0;
 }


### PR DESCRIPTION
처음 렌더되고, 인덱스가 돌기 전에 잠깐 사라졌다가 나오는 버그 수정